### PR TITLE
Use readlink instead of realpath

### DIFF
--- a/tesmart.sh
+++ b/tesmart.sh
@@ -427,7 +427,7 @@ then
     esac
   done
 
-  TESMART_CONFIG="$(realpath "$TESMART_CONFIG")"
+  TESMART_CONFIG="$(readlink -f -- "$TESMART_CONFIG")"
   if [[ -r "$TESMART_CONFIG" ]]
   then
     if [[ -n "$DEBUG" ]]


### PR DESCRIPTION
The `readlink` executable does not exist on an OSX by default.

The functionality is the same and works at least on Ubuntu and OSX
out of the box.
