### PR TITLE
Avoid cat -E

### DIFF
--- a/tesmart.sh
+++ b/tesmart.sh
@@ -112,8 +112,8 @@ send_cmd_retry() {
     if [[ -n "$DEBUG" ]]
     then
       {
-        echo "Raw output: $(cat -vE <<< "$res")"
-        echo "Printable output: \"$(tr -dc '[:print:]' <<< "$res" | cat -vE)\""
+        echo "Raw output: $(cat -v <<< "$res")"
+        echo "Printable output: \"$(tr -dc '[:print:]' <<< "$res" | cat -v)\""
       } >&2
     fi
 


### PR DESCRIPTION
Apparently the OSX cat does not support the -E flag used in debug mode.

Unless it is really important, let's just not use it.
